### PR TITLE
Feature: Add subnet support for iOS and Android

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,10 +23,29 @@ The plugin creates the object `networkinterface` with the methods:
 
 `This method is deprecated and uses the getWiFiIPAddress method.`
 
+The onSuccess() callback is provided with two values: 
+
+    function onSuccess(ip, subnet) { }
+
+`Note: Subnet is only supported for iOS and Android currently`
+
+The onError() callback is provided with a single value:
+
+    function onError(error) { }
+
+`Note: onError() will be called when an IP address can't be found. eg WiFi is disabled, no SIM card, Airplane mode etc.
+`
+
 Example:
 
 	networkinterface.getWiFiIPAddress(function (ip) { alert(ip); });
 	networkinterface.getCarrierIPAddress(function (ip) { alert(ip); });
+    
+    // with subnet and error handler
+    networkinterface.getWiFiIPAddress(
+        function (ip, subnet) { alert(ip + ":" + subnet); }, 
+        function (err) { alert("Err: " + err); }
+    );
 
 ## TODO
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cordova-plugin-networkinterface",
-  "version": "1.1.0",
+  "version": "1.2.0",
   "description": "This plugin allows your application to retrieve the local wifi address.",
   "cordova": {
     "id": "cordova-plugin-networkinterface",

--- a/src/android/networkinterface.java
+++ b/src/android/networkinterface.java
@@ -4,6 +4,7 @@ import org.apache.cordova.CordovaPlugin;
 import org.apache.cordova.CallbackContext;
 import org.apache.cordova.CordovaInterface;
 import org.apache.cordova.CordovaWebView;
+import org.apache.cordova.PluginResult;
 import org.json.JSONArray;
 import org.json.JSONException;
 
@@ -14,8 +15,10 @@ import android.util.Log;
 
 import java.net.InetAddress;
 import java.net.Inet4Address;
+import java.net.InterfaceAddress;
 import java.net.NetworkInterface;
 import java.net.SocketException;
+import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
 import java.util.Enumeration;
@@ -30,22 +33,32 @@ public class networkinterface extends CordovaPlugin {
 	public boolean execute(String action, JSONArray args, CallbackContext callbackContext) throws JSONException {
 		try {
 			if (GET__WIFI_IP_ADDRESS.equals(action)) {
-				String ip = getWiFiIPAddress();
+				String[] ipInfo = getWiFiIPAddress();
+				String ip = ipInfo[0];
+				String subnet = ipInfo[1];
 				String fail = "0.0.0.0";
-				if (ip.equals(fail)) {
+				if (ip == null || ip.equals(fail)) {
 					callbackContext.error("No valid IP address identified");
 					return false;
 				}
-				callbackContext.success(ip);
+				List<PluginResult> result = new ArrayList<PluginResult>();
+				result.add(new PluginResult(PluginResult.Status.OK, ip));
+				result.add(new PluginResult(PluginResult.Status.OK, subnet));
+				callbackContext.sendPluginResult(new PluginResult(PluginResult.Status.OK, result));
 				return true;
 			} else if (GET_CARRIER_IP_ADDRESS.equals(action)) {
-				String ip = getCarrierIPAddress();
+				String[] ipInfo = getCarrierIPAddress();
+				String ip = ipInfo[0];
+				String subnet = ipInfo[1];
 				String fail = "0.0.0.0";
-				if (ip.equals(fail)) {
+				if (ip == null || ip.equals(fail)) {
 					callbackContext.error("No valid IP address identified");
 					return false;
 				}
-				callbackContext.success(ip);
+				List<PluginResult> result = new ArrayList<PluginResult>();
+				result.add(new PluginResult(PluginResult.Status.OK, ip));
+				result.add(new PluginResult(PluginResult.Status.OK, subnet));
+				callbackContext.sendPluginResult(new PluginResult(PluginResult.Status.OK, result));
 				return true;
 			}
 			callbackContext.error("Error no such method '" + action + "'");
@@ -56,8 +69,8 @@ public class networkinterface extends CordovaPlugin {
 		}
 	}
 
-	private String getWiFiIPAddress() {
-		WifiManager wifiManager = (WifiManager) cordova.getActivity().getSystemService(Context.WIFI_SERVICE);
+	private String[] getWiFiIPAddress() {
+		WifiManager wifiManager = (WifiManager) cordova.getActivity().getApplicationContext().getSystemService(Context.WIFI_SERVICE);
 		WifiInfo wifiInfo = wifiManager.getConnectionInfo();
 		int ip = wifiInfo.getIpAddress();
 
@@ -69,29 +82,61 @@ public class networkinterface extends CordovaPlugin {
 			(ip >> 24 & 0xff)
 			);
 
-		return ipString;
+		String subnet = "";
+		try {
+			InetAddress inetAddress = InetAddress.getByName(ipString);
+			subnet = getIPv4Subnet(inetAddress);
+		} catch (Exception e) {
+		}
+
+		return new String[]{ ipString, subnet };
 	}
 
-
-
-	private String getCarrierIPAddress() { 
+	private String[] getCarrierIPAddress() {
 	  try {
 	    for (Enumeration<NetworkInterface> en = NetworkInterface.getNetworkInterfaces(); en.hasMoreElements();) {
 	       NetworkInterface intf = (NetworkInterface) en.nextElement();
 	       //Log.e(TAG, "Interface: " + intf.toString() + " name: " + intf.getName() + " display nane: " + intf.getDisplayName() );
 	       for (Enumeration<InetAddress> enumIpAddr = intf.getInetAddresses(); enumIpAddr.hasMoreElements();) {
 	          InetAddress inetAddress = enumIpAddr.nextElement();
-	          if (!inetAddress.isLoopbackAddress() && (!intf.getName().equals("wlan0")) && inetAddress instanceof Inet4Address) {
-	             String ipaddress = inetAddress.getHostAddress().toString();
-	             return ipaddress;
+			   if (!inetAddress.isLoopbackAddress() && (!intf.getName().equals("wlan0")) && inetAddress instanceof Inet4Address) {
+				   String ipaddress = inetAddress.getHostAddress().toString();
+				   String subnet = getIPv4Subnet(inetAddress);
+				   return new String[]{ ipaddress, subnet };
 	          }
 	       }
 	    }
 	  } catch (SocketException ex) {
 	     Log.e(TAG, "Exception in Get IP Address: " + ex.toString());
 	  }
-	  return null;
+	  return new String[]{ null, null };
 	}
 
+	public static String getIPv4Subnet(InetAddress inetAddress) {
+		try {
+			NetworkInterface ni = NetworkInterface.getByInetAddress(inetAddress);
+			List<InterfaceAddress> intAddrs =  ni.getInterfaceAddresses();
+			for (InterfaceAddress ia : intAddrs) {
+				if (!ia.getAddress().isLoopbackAddress() && ia.getAddress() instanceof Inet4Address) {
+					return getIPv4SubnetFromNetPrefixLength(ia.getNetworkPrefixLength()).getHostAddress().toString();
+				}
+			}
+		} catch (Exception e) {
+		}
+		return "";
+	}
 
+	public static InetAddress getIPv4SubnetFromNetPrefixLength(int netPrefixLength) {
+		try {
+			int shift = (1<<31);
+			for (int i=netPrefixLength-1; i>0; i--) {
+				shift = (shift >> 1);
+			}
+			String subnet = Integer.toString((shift >> 24) & 255) + "." + Integer.toString((shift >> 16) & 255) + "." + Integer.toString((shift >> 8) & 255) + "." + Integer.toString(shift & 255);
+			return InetAddress.getByName(subnet);
+		}
+		catch(Exception e){
+		}
+		return null;
+	}
 }

--- a/src/ios/CDVNetworkInterface.m
+++ b/src/ios/CDVNetworkInterface.m
@@ -2,9 +2,10 @@
 
 @implementation CDVNetworkInterface
 
-- (NSString *)getWiFiIP {
+- (NSArray *)getWiFiIP {
 
     NSString *address = @"error";
+    NSString *subnet = @"error";
     struct ifaddrs *interfaces = NULL;
     struct ifaddrs *temp_addr = NULL;
     int success = 0;
@@ -19,7 +20,7 @@
                 if([[NSString stringWithUTF8String:temp_addr->ifa_name] isEqualToString:@"en0"]) {
                     // Get NSString from C String
                     address = [NSString stringWithUTF8String:inet_ntoa(((struct sockaddr_in *)temp_addr->ifa_addr)->sin_addr)];
-
+                    subnet = [NSString stringWithUTF8String:inet_ntoa(((struct sockaddr_in *)temp_addr->ifa_netmask)->sin_addr)];
                 }
 
             }
@@ -29,13 +30,14 @@
     }
     // Free memory
     freeifaddrs(interfaces);
-    return address;
+    return (NSArray*)@[address, subnet];
 }
 
-- (NSString *)getCarrierIP {
+- (NSArray *)getCarrierIP {
     struct ifaddrs *interfaces = NULL;
     struct ifaddrs *temp_addr = NULL;
-    NSString *cellAddress = nil;
+    NSString *cellAddress = @"error";
+    NSString *cellSubnet = @"error";
 
     // retrieve the current interfaces - returns 0 on success
     if(!getifaddrs(&interfaces)) {
@@ -51,6 +53,7 @@
                 if([name isEqualToString:@"pdp_ip0"] && ![addr isEqualToString:@"0.0.0.0"]) {
                     // Interface is the cell connection on the iPhone
                     cellAddress = addr;
+                    cellSubnet = [NSString stringWithUTF8String:inet_ntoa(((struct sockaddr_in *)temp_addr->ifa_netmask)->sin_addr)];
                 }
             }
             temp_addr = temp_addr->ifa_next;
@@ -59,19 +62,21 @@
         freeifaddrs(interfaces);
     }
 
-    return cellAddress;
+    return (NSArray *)@[cellAddress, cellSubnet];
 }
 
 
 - (void) getWiFiIPAddress:(CDVInvokedUrlCommand*)command
 {
     CDVPluginResult* pluginResult = nil;
-    NSString* ipaddr = [self getWiFiIP];
-
+    NSArray* ipinfo = [self getWiFiIP];
+    NSString* ipaddr = ipinfo[0];
+    NSString* ipsubnet = ipinfo[1];
+    
     if (ipaddr != nil && ![ipaddr isEqualToString:@"error"]) {
-        pluginResult = [CDVPluginResult resultWithStatus:CDVCommandStatus_OK messageAsString:ipaddr];
+        pluginResult = [CDVPluginResult resultWithStatus:CDVCommandStatus_OK messageAsMultipart:@[ipaddr, ipsubnet]];
     } else {
-        pluginResult = [CDVPluginResult resultWithStatus:CDVCommandStatus_ERROR];
+        pluginResult = [CDVPluginResult resultWithStatus:CDVCommandStatus_ERROR messageAsString:@"No valid IP address identified"];
     }
 
     [self.commandDelegate sendPluginResult:pluginResult callbackId:command.callbackId];
@@ -80,12 +85,14 @@
 - (void) getCarrierIPAddress:(CDVInvokedUrlCommand*)command
 {
     CDVPluginResult* pluginResult = nil;
-    NSString* ipaddr = [self getCarrierIP];
-
+    NSArray *ipinfo = [self getCarrierIP];
+    NSString *ipaddr = ipinfo[0];
+    NSString *ipsubnet = ipinfo[1];
+    
     if (ipaddr != nil && ![ipaddr isEqualToString:@"error"]) {
-        pluginResult = [CDVPluginResult resultWithStatus:CDVCommandStatus_OK messageAsString:ipaddr];
+        pluginResult = [CDVPluginResult resultWithStatus:CDVCommandStatus_OK messageAsMultipart:@[ipaddr, ipsubnet]];
     } else {
-        pluginResult = [CDVPluginResult resultWithStatus:CDVCommandStatus_ERROR];
+        pluginResult = [CDVPluginResult resultWithStatus:CDVCommandStatus_ERROR messageAsString:@"No valid IP address identified"];
     }
 
     [self.commandDelegate sendPluginResult:pluginResult callbackId:command.callbackId];


### PR DESCRIPTION
This PR adds subnet support (i.e. netmask info) for both iOS and Android. (maybe more platforms in a future PR)

The subnet info is provided to the onSuccess() callback as a separate argument (string value).
Eg
```javascript
function onSuccess(ip, subnet) { }
```

This was simply following your comment:
> I think to avoid a soup of callbacks we can probably return the netmask in the IP request as a seperate argument in the callback.

The code can easily return additional information now using separate arguments if you choose to in the future. However, depending on how much additional information you want to provide in the future I'd maybe suggest providing an object of additionalInfo eg `{ subnet: '255.255.255.0', gateway: '192.168.1.1', broadcast: '...' }` etc to avoid "argument hell". But I'll leave this future decision to you.

I've tested this plugin on an iPhone 6 plus, iPad 2017, Galaxy Note II and Moto G3 and all work successfully. iOS and Android behave a little differently, where iOS seems to give the Carrier info when WiFi is on, but Android will not give the Carrier info until you turn WiFi off. i.e. Android only provides the currently used radio (but I believe this was the behavior before this PR anyway). The `onError()` callback is called when the respective radio is disabled (i.e. previous behaviour). i.e. Airplane mode, WiFi off, No SIM card etc

To test this PR on your own device, prior to merging, run the following commands:

```
cordova create subnetTest com.yourcompany.app
cd subnetTest
cordova platform add ios
cordova platform add android
cordova plugin add https://github.com/dharders/cordova-plugin-networkinterface.git
```
Then simply add to `/www/js/index.js` in the onDeviceReady function()

```javascript
networkinterface.getWiFiIPAddress(
    function (ip, subnet) { print('WiFi: ' + ip + ' : ' + subnet) }, 
    function (err) { print('WiFi Err: ' + ip + ' : ' + subnet) }
);
networkinterface.getCarrierIPAddress(
    function (ip, subnet) { print('Carrier: ' + ip + ' : ' + subnet }, 
    function (err) { print('Carrier Err: ' + ip + ' : ' + subnet }
);
var print = function (text) {
    var el = document.getElementById('deviceready');
    var h3 = document.createElement("h3");
    var t = document.createTextNode(text);
    h3.appendChild(t);
    el.appendChild(h3);
}
```
Finally
```
cordova run ios     (or android)
```

P.S. I updated the README to reflect the new feature and also updated the version number to 1.2.0 since a feature was added and semver rules etc.

P.P.S. great plugin. Happy to contribute ;)

Closes #12 
